### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-semgrep.yml
+++ b/.github/workflows/lint-semgrep.yml
@@ -1,5 +1,7 @@
 name: Lint & Semgrep
 on: [push, pull_request, workflow_dispatch]
+permissions:
+  contents: read
 
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/htomasz/vultron/security/code-scanning/22](https://github.com/htomasz/vultron/security/code-scanning/22)

In general, the fix is to explicitly define a `permissions:` block to restrict the `GITHUB_TOKEN` to the minimal scopes required. For a linting and Semgrep scanning workflow that only needs to read repository code, `contents: read` is sufficient as a baseline.

The best fix here is to add a workflow-level `permissions:` block right after the `name:` or `on:` declaration in `.github/workflows/lint-semgrep.yml`. This will apply to all jobs (currently just `lint`) unless overridden. We’ll set `contents: read`, which allows checkout and scanning but prevents unintended write operations to the repo. No other scopes (`pull-requests`, `issues`, etc.) are needed based on the shown steps, and no existing behavior will be changed because the actions used do not require write access.

Concretely, in `.github/workflows/lint-semgrep.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and `jobs:` (or directly after `name:` if preferred). No imports or additional methods are required, as this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
