### PR TITLE
Potential fix for code scanning alert no. 25: Insecure randomness

### DIFF
--- a/vultron/vultron-zebrania-card.js
+++ b/vultron/vultron-zebrania-card.js
@@ -1,7 +1,13 @@
 class VultronZebraniaCard extends HTMLElement {
   constructor() {
     super();
-    this._uid = 'vz-' + Math.random().toString(36).substr(2, 9);
+    this._uid = 'vz-' + (
+      globalThis.crypto?.randomUUID
+        ? globalThis.crypto.randomUUID()
+        : Array.from(globalThis.crypto.getRandomValues(new Uint8Array(16)))
+            .map((b) => b.toString(16).padStart(2, '0'))
+            .join('')
+    );
     this._sortOrder = null;
     this._cachedSignature = null;
     this._currentZebrania = [];


### PR DESCRIPTION
Potential fix for [https://github.com/htomasz/vultron/security/code-scanning/25](https://github.com/htomasz/vultron/security/code-scanning/25)

Use a cryptographically secure random source for `_uid` generation in the constructor, instead of `Math.random()`.

Best fix in this file: replace line 4 with a Web Crypto API-based UUID when available (`globalThis.crypto.randomUUID()`), with a secure fallback using `crypto.getRandomValues` to create a hex suffix. This keeps functionality (unique per-instance string ID prefixed with `vz-`) while removing insecure randomness.

Change needed in `vultron/vultron-zebrania-card.js`:
- In `constructor()`, replace:
  - `this._uid = 'vz-' + Math.random().toString(36).substr(2, 9);`
- With a CSPRNG-backed assignment:
  - Prefer `globalThis.crypto.randomUUID()`
  - Fallback to `globalThis.crypto.getRandomValues(new Uint8Array(16))` + hex encoding

No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
