### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-security.yml
+++ b/.github/workflows/python-security.yml
@@ -2,6 +2,9 @@ name: Python Security Scan
 
 on: [push, pull_request,workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   security:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/htomasz/vultron/security/code-scanning/28](https://github.com/htomasz/vultron/security/code-scanning/28)

Add an explicit workflow-level `permissions` block in `.github/workflows/python-security.yml` so all jobs inherit least privilege by default.  
For this workflow, the minimal non-breaking permission is:

- `contents: read`

Place it near the top level (after `on:` is a common location), before `jobs:`. This keeps functionality unchanged while satisfying CodeQL and documenting intended token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
