### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -2,6 +2,9 @@ name: Dockerfile Linter
 
 on: [push, pull_request,workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   hadolint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/htomasz/vultron/security/code-scanning/27](https://github.com/htomasz/vultron/security/code-scanning/27)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to the minimum required scope.  
Best fix without changing functionality: set workflow-level permissions to `contents: read`, since this workflow only checks out code and lints it.

Edit **`.github/workflows/hadolint.yml`** near the top-level keys:
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it after `on:` (or before `jobs:`) so it applies to all jobs in the workflow.

No new methods/imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
