### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -2,6 +2,9 @@ name: Secret Scanning
 
 on: [push, pull_request,workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/htomasz/vultron/security/code-scanning/26](https://github.com/htomasz/vultron/security/code-scanning/26)

Add an explicit `permissions` block to `.github/workflows/gitleaks.yml` at the workflow root level (right after `on` is a clean location). For this workflow, the minimal required permission is `contents: read` since it checks out code and scans it; no write scope is needed.

This preserves existing functionality while enforcing least privilege for `GITHUB_TOKEN` across jobs in this workflow (currently just `gitleaks`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
